### PR TITLE
Replaces Table class with ITable interface.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { Construct, RemovalPolicy, Duration } from '@aws-cdk/core';
-import { Table } from '@aws-cdk/aws-dynamodb';
+import { ITable } from '@aws-cdk/aws-dynamodb';
 import { Function, Runtime, Code } from '@aws-cdk/aws-lambda';
 import { Bucket } from '@aws-cdk/aws-s3';
 import { BucketDeployment, Source } from '@aws-cdk/aws-s3-deployment';
@@ -8,7 +8,7 @@ import * as tmp from 'tmp';
 import * as fs from 'fs';
 
 export interface Props {
-  readonly table: Table;
+  readonly table: ITable;
   readonly setup: Item[];
   readonly teardown?: ItemKey[];
   readonly refreshOnUpdate?: boolean;


### PR DESCRIPTION
This commit addresses issue #36.

The Seeder works for new tables being created via CDK, but existing tables
using `fromTableArn` or `fromTableAttributes` fail.

Changing the Props type to ITable allows for new and existing tables.

**Tests**
Tests still pass successfully with this change.



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

<!-- 
Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/elegantdevelopment/aws-cdk-dynamodb-seeder/blob/master/CONTRIBUTING.md
 -->
